### PR TITLE
Extend clojure.test using multi method 'assert-expr'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,30 +19,23 @@ expected: (= {:first-name "John", :last-name "Smith"} {:first-name "Johnny", :la
 With complex and possibly nested data structures it is hard to read what was actually wrong. With matcher like this
 
 ```clojure
-(deftest my-test-with-matcher (is (contains-exactly? {:first-name "John" :last-name "Smith"} {:first-name "Johnny" :last-name "Smith"})))
+(deftest my-test-with-matcher (is (equal? {:first-name "John" :last-name "Smith"} {:first-name "Johnny" :last-name "Smith"})))
 ```
 
 you get following output:
 
 ```
-- - - Missing:
-{:first-name "John"}
+FAIL in (my-test-with-matcher) (form-init7128815568440584833.clj:1)
 
-- - - Unexpected content:
+-- missing:
 {:first-name "Johnny"}
-
-- - - Expected:
-{:last-name "Smith", :first-name "Johnny"}
-
-- - - Actual:
-{:last-name "Smith", :first-name "John"}
-
-FAIL in (my-test-with-matcher) (form-init7375693162901327698.clj:1)
-expected: (clj-containment-matchers.core/contains-exactly? {:first-name "John", :last-name "Smith"} {:first-name "Johnny", :last-name "Smith"})
-  actual: (not (clj-containment-matchers.core/contains-exactly? {:last-name "Smith", :first-name "John"} {:last-name "Smith", :first-name "Johnny"}))
+++ unexpected:
+{:first-name "John"}
+expected: {:first-name "Johnny", :last-name "Smith"}
+  actual: {:last-name "Smith", :first-name "John"}
 ```
 
-From the output it is much easier to check what field was missing or what field had incorrect value.
+From the output it is easier to check what field was missing or what field had incorrect value.
 
 # Installation
 
@@ -55,18 +48,26 @@ Add the following to your `project.clj` `:dependencies`:
 # Usage
 
 ```clojure
-(require [clj-containment-matchers.core :refer :all])
+(require [clj-containment-matchers.clojure-test :refer :all])
 ```
 Check whether two items contain exactly the same values
 
 ```clojure
-(contains-exactly? actual expected)
+(is (equal? actual expected)
+
+(is (not-equal? actual expected)
 ```
 
 Ignore some field from the match (e.g. timestamp)
 
 ```clojure
-(contains-exactly? {:name "John" :timestamp 219898989} {:name "John" :timestamp anything})
+(is (equal? {:name "John" :timestamp 219898989} {:name "John" :timestamp anything})
+```
+
+anything is a function that clj-containment-matchers provide but you can use any Clojure function like this:
+
+```clojure
+(is (equal? {:name "John" :age 21} {:name "John" :age number?})
 ```
 
 #License

--- a/src/clj_containment_matchers/clojure_test.clj
+++ b/src/clj_containment_matchers/clojure_test.clj
@@ -1,37 +1,34 @@
 (ns clj-containment-matchers.clojure-test
   (:require [clj-containment-matchers.diff :refer [diff]]
             [clojure.pprint :refer [pprint]]
-            [clojure.test :refer [do-report]]))
+            [clojure.test :refer [do-report assert-expr]]))
 
 (defn anything [_] true)
 
-(defmethod clojure.test/report :fail-without-formatting [m]
-  (clojure.test/with-test-out
-    (clojure.test/inc-report-counter :fail)
-    (println "\nFAIL in" (clojure.test/testing-vars-str m))
-    (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))
-    (when-let [message (:message m)] (println message))
-    (println "expected:\n" (:expected m))
-    (println "actual:\n" (:actual m))))
-
-;This needs to be macro in order to have the correct line numbers in failure report
-(defmacro contains-exactly?
-  "Asserts that expected and actual have exactly same."
-  [actual expected]
- `(let [pretty# #(with-out-str (pprint %))
-        [things-only-in-actual# things-only-in-expected# things-in-both#] (diff ~actual ~expected)
+(defmethod assert-expr 'equal? [_ form]
+  "Asserts that expected and actual are exactly same. Prints a diff when not."
+  (let [actual (nth form 1)
+        expected (nth form 2)]
+ `(let [[things-only-in-actual# things-only-in-expected# things-in-both#] (diff ~actual ~expected)
         missing-expected-error-msg# (when things-only-in-expected#
-                                      (str "-- missing:\n" (pretty# things-only-in-expected#)))
+                                      (str "-- missing:\n" things-only-in-expected#))
         unexpected-error-msg# (when things-only-in-actual#
-                               (str "\n++ unexpected:\n" (pretty# things-only-in-actual#)))
+                               (str "\n++ unexpected:\n" things-only-in-actual#))
         error-msg# (str "\n" missing-expected-error-msg# unexpected-error-msg#)
-        success?# (and (empty? things-only-in-expected#) (empty? things-only-in-actual#))
-        [file# line#] (let [stacktrace# (.getStackTrace (RuntimeException.))
-                            ^StackTraceElement s# (first stacktrace#)]
-                        [(.getFileName s#)  (.getLineNumber s#)])]
-    (do-report {:type (if success?# :pass :fail-without-formatting)
+        success?# (and (empty? things-only-in-expected#) (empty? things-only-in-actual#))]
+    (do-report {:type (if success?# :pass :fail)
                 :message error-msg#
-                :expected (pretty# '~expected)
-                :actual (pretty# ~actual)
-                :file file#
-                :line line#})))
+                :expected '~expected
+                :actual ~actual}))))
+
+(defmethod assert-expr 'not-equal? [_ form]
+  "Asserts that expected and actual are not the same."
+  (let [actual (nth form 1)
+        expected (nth form 2)]
+ `(let [[things-only-in-actual# things-only-in-expected# things-in-both#] (diff ~actual ~expected)
+        success?# (not (and (empty? things-only-in-expected#)
+                            (empty? things-only-in-actual#)))]
+    (do-report {:type (if success?# :pass :fail)
+                :message "Should not be equal"
+                :expected '~expected
+                :actual ~actual}))))

--- a/test/clj_containment_matchers/core_test.clj
+++ b/test/clj_containment_matchers/core_test.clj
@@ -1,44 +1,40 @@
 (ns clj-containment-matchers.core-test
   (:require [clojure.test :refer :all]
             [clj-containment-matchers.diff :refer [diff]]
-            [clj-containment-matchers.clojure-test :refer [anything contains-exactly?]]))
-
-(defmacro does-not-contain-exactly? [actual expected]
-  `(let [[things-only-in-actual# things-only-in-expected# things-in-both#] (diff ~actual ~expected)]
-     (is (or things-only-in-actual# things-only-in-expected#))))
+            [clj-containment-matchers.clojure-test :refer :all]))
 
 (deftest contains-exactly?-function
   (testing "compares arrays"
-    (contains-exactly? [1 2 3] [1 2 anything])
-    (contains-exactly? ["1" "2" "3"] ["1" string? "3"])
-    (contains-exactly? [1 2 3] [number? 2 3])
-    (does-not-contain-exactly? [1 2 3] [1 3 3])
-    (does-not-contain-exactly? [1 2 3] [1 1 3])
-    (does-not-contain-exactly? [1 2 3] [2 2 3]))
+    (is (equal? [1 2 3] [1 2 anything]))
+    (is (equal? ["1" "2" "3"] ["1" string? "3"]))
+    (is (equal? [1 2 3] [number? 2 3]))
+    (is (not-equal? [1 2 3] [1 3 3]))
+    (is (not-equal? [1 2 3] [1 1 3]))
+    (is (not-equal? [1 2 3] [2 2 3])))
   (testing "compares nested arrays"
-    (contains-exactly? [1 [2 [3]]] [1 [2 [3]]])
-    (contains-exactly? [1 [2 [3]]] [1 [2 [number?]]])
-    (contains-exactly? ["1" ["2" ["3"]]] ["1" [string? ["3"]]])
-    (does-not-contain-exactly? [1 [2 [3]]] [1 [3 [3]]])
-    (does-not-contain-exactly? [1 [2 [3]]] [1 [2 [string?]]])
-    (does-not-contain-exactly? ["1" ["2" ["3"]]] ["1" [number? ["3"]]]))
+    (is (equal? [1 [2 [3]]] [1 [2 [3]]]))
+    (is (equal? [1 [2 [3]]] [1 [2 [number?]]]))
+    (is (equal? ["1" ["2" ["3"]]] ["1" [string? ["3"]]]))
+    (is (not-equal? [1 [2 [3]]] [1 [3 [3]]]))
+    (is (not-equal? [1 [2 [3]]] [1 [2 [string?]]]))
+    (is (not-equal? ["1" ["2" ["3"]]] ["1" [number? ["3"]]])))
   (testing "compares maps"
-     (contains-exactly? {:name "john" :id "1"} {:name "john" :id anything})
-     (does-not-contain-exactly? {:name "john" :id 1} {:name "john" :id string?}))
+     (is (equal? {:name "john" :id "1"} {:name "john" :id anything}))
+     (is (not-equal? {:name "john" :id 1} {:name "john" :id string?})))
   (testing "compares nested maps"
-    (contains-exactly? {:name "john" :phone-numbers {"home" "123" "work" "456"}}
-                       {:name "john" :phone-numbers {"home" "123" "work" string?}})
-    (does-not-contain-exactly? {:name "john" :phone-numbers {"home" "123" "work" "456"}}
-                               {:name "john" :phone-numbers {"home" "123" "work-2" "456"}}))
+    (is (equal? {:name "john" :phone-numbers {"home" "123" "work" "456"}}
+                {:name "john" :phone-numbers {"home" "123" "work" string?}}))
+    (is (not-equal? {:name "john" :phone-numbers {"home" "123" "work" "456"}}
+                    {:name "john" :phone-numbers {"home" "123" "work-2" "456"}})))
   (testing "compares sets"
-    (contains-exactly? #{1 2 3} #{2 1 3})
-    (does-not-contain-exactly?  #{1 2 3} #{1 2 4}))
+    (is (equal? #{1 2 3} #{2 1 3}))
+    (is (not-equal? #{1 2 3} #{1 2 4})))
   (testing "compares nested structures with different types of collections"
-    (contains-exactly?
+    (is (equal?
       [{:type "Test"
         :node {:data {:title "My test node"}
                :id 1}}]
       [{:type "Test"
         :node {:data {:title string?}
-               :id (fn [x] (and (> x 0) (< x 10)))}}])
-    (contains-exactly? {:id 1 :link []} {:id anything :link []})))
+               :id (fn [x] (and (> x 0) (< x 10)))}}]))
+    (is (equal? {:id 1 :link []} {:id anything :link []}))))


### PR DESCRIPTION
Instead of having separate macro 'contains-exactly?' which replaces the
'is' macro we now extend clojure.test by adding two new assertions

(is (equal? actual expected))
AND
(is (not-equal? actual expected))

This is a de facto way that most of the other testing frameworks use for
adding custom assertions and it is a recommended approach according to
clojure.test documentation.

Now 'with-junit-output' also works as expected. It was broken in version 1.0.0.

Note! This does not provide as nice pretty printing yet than previous version did.
